### PR TITLE
[FIX] passing session as non-positional argument

### DIFF
--- a/litstudy/sources/semanticscholar.py
+++ b/litstudy/sources/semanticscholar.py
@@ -196,7 +196,7 @@ def refine_semanticscholar(docs: DocumentSet, *, session=None) -> Tuple[Document
         if isinstance(doc, ScholarDocument):
             return doc
 
-        return fetch_semanticscholar(doc.id, session)
+        return fetch_semanticscholar(doc.id, session=session)
 
     return docs._refine_docs(callback)
 


### PR DESCRIPTION
when executing `refine_semanticscholar(...)`, the following error was thrown:

`TypeError: fetch_semanticscholar() takes 1 positional argument but 2 were given`

Fixed with this PR.