### PR TITLE
Update tsne function due to dependency change in nlp.py

### DIFF
--- a/litstudy/nlp.py
+++ b/litstudy/nlp.py
@@ -408,6 +408,6 @@ def calculate_embedding(corpus: Corpus, *, rank=2, svd_dims=50, perplexity=30, s
         components = tfidf
 
     model = TSNE(
-        rank, metric="cosine", square_distances=True, perplexity=perplexity, random_state=seed
+        rank, metric="cosine", perplexity=perplexity, random_state=seed
     )
     return model.fit_transform(components)


### PR DESCRIPTION
The recent update to a dependency removed the need for the 'square_distance' argument in the tsne function, which is used within the calculate_embedding function in the nlp module. This commit updates the tsne function to no longer require the 'square_distance' argument.

Fixes #54 