### PR TITLE
bug fix: restricting scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scikit-learn
 unidecode
 wordcloud
 feedparser
+scipy<1.13


### PR DESCRIPTION
Running the notebook results in the error message:

`cannot import name 'triu' from 'scipy.linalg'`

This PR restricts the version of scipy to avoid the import error message

See: https://stackoverflow.com/questions/78279136/importerror-cannot-import-name-triu-from-scipy-linalg-gensim